### PR TITLE
Variable length IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ If you want to switch off the tracing messages then alter the log level as follo
 logging.getLogger('b3').setLevel('WARNING')
 ```
 
+### Change Trace/Span character length
+
+By default, both `trace` and `span` identifiers generated will be a 16-character hexadecimal encoding of an 8-byte array, as determined by the `trace_len` and `span_len` parameters.
+In some cases you may wish to change this. 
+For example, the Stackdriver Trace API expects the `trace` id to be 32 characters and the `span` id to be 16, do this as follows
+```
+b3.trace_len = 32
+```
+
 ## Other stuff
 
 This library has no dependencies.

--- a/b3/__init__.py
+++ b/b3/__init__.py
@@ -1,14 +1,17 @@
-from functools import wraps
-
-from threading import local
-from binascii import hexlify
-import os
 import logging
+import os
+from binascii import hexlify
+from functools import wraps
+from threading import local
 
 _log = logging.getLogger(__name__)
 _log.setLevel(logging.INFO)
 
+# config
 debug = False
+trace_len = 16
+span_len = 16
+
 
 b3_trace_id = 'X-B3-TraceId'
 b3_parent_span_id = 'X-B3-ParentSpanId'
@@ -58,7 +61,7 @@ def start_span(headers):
     root_span = not trace_id
 
     # Collect (or generate) a trace ID
-    b3.span[b3_trace_id] = trace_id or _generate_identifier()
+    b3.span[b3_trace_id] = trace_id or _generate_identifier(trace_len)
 
     # Parent span, if present
     b3.span[b3_parent_span_id] = parent_span_id
@@ -175,7 +178,7 @@ def _start_subspan(headers=None):
         b3_trace_id: parent[b3_trace_id],
 
         # Start a new span for the outgoing request
-        b3_span_id: _generate_identifier(),
+        b3_span_id: _generate_identifier(span_len),
 
         # Set the current span as the parent span
         b3_parent_span_id: parent[b3_span_id],
@@ -216,12 +219,12 @@ def _end_subspan():
         delattr(b3, "subspan")
 
 
-def _generate_identifier():
+def _generate_identifier(identifier_length):
     """
     Generates a new, random identifier in B3 format.
     :return: A 64-bit random identifier, rendered as a hex String.
     """
-    bit_length = 64
+    bit_length = identifier_length * 4
     byte_length = int(bit_length / 8)
     identifier = os.urandom(byte_length)
     return hexlify(identifier).decode('ascii')

--- a/b3/__init__.py
+++ b/b3/__init__.py
@@ -67,7 +67,7 @@ def start_span(headers):
     b3.span[b3_parent_span_id] = parent_span_id
 
     # Collect (or set) the span ID
-    b3.span[b3_span_id] = span_id or b3.span.get(b3_trace_id)
+    b3.span[b3_span_id] = span_id or _generate_identifier(span_len)
 
     # Collect the "sampled" flag, if present
     # We'll propagate the sampled value unchanged if it's set.

--- a/examples/app.py
+++ b/examples/app.py
@@ -1,12 +1,14 @@
 """
 NB: This example requires Flask to run.
 """
-from flask import Flask, jsonify, request
 import logging
+
+from flask import Flask, jsonify, request
+
 import b3
 from b3 import span
 
-
+b3.trace_len = 32
 app = Flask("test")
 
 # Before and after request to process B3 values and log span boundaries

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def test_suite():
 
 
 setup(name='B3-Propagation',
-      version='0.1.4',
+      version='0.1.5',
       description='B3 header access and propagation for Python.',
       author='David Carboni',
       author_email='david@carboni.io',


### PR DESCRIPTION
The Stackdriver Trace API expects IDs in this format:

> [TRACE_ID] is a unique identifier for a trace within a project;
>  it is a 32-character hexadecimal encoding of a 16-byte array.
> 
> [SPAN_ID] is a unique identifier for a span within a trace; it
> is a 16-character hexadecimal encoding of an 8-byte array.

Currently B3-Propagation only supports ID generation of 16 characters.
I have made changes such that the length of both IDs can be changed.
As a side effect, this has resulted in the decoupling of span and trace IDs.